### PR TITLE
8: rename module and package as specified in the regulations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,19 @@
-# octopus-corelibs-oc\_cdtapi
+# octopus-oc-corelibs-cdtapi
 
 ## Core libraries consist of:
 
-- API.py — an extension to python requests
-- DevPIAPI.py — class dealing with Python Index
-— DmsAPI.py — an api to dms
-- DmsGetverAPI.py — an api to dms get version
-- ForemanAPI.py — an api to foreman
-- JenkinsAPI.py — an api to jenkins
-- NexusAPI.py — an api to nexus / artifactory
-- TestServer.py — mock http server for testing of API.py based modules
-- nexus.py — cli dealing with nexus / artifactory. Upload, download, delete artifacts
-- okd — template for openshift OKD
+- *oc\_cdtapi* module
+    - API.py — an extension to python requests for http/https quieries
+    - DevPIAPI.py — class dealing with Python Index
+    — DmsAPI.py — an API to Distributive Management System (some propieritary implementations)
+    - DmsGetverAPI.py — an API to GetVersion part of Distributive Management System (some propieritary implementations)
+    - ForemanAPI.py — an API to Foreman (limited)
+    - JenkinsAPI.py — an API to Jenkins v.1.x
+    - NexusAPI.py — an API to Maven-compatible storage (currently Sonatype Nexus and JFrog Artifactory)
+    - TestServer.py — Mock HTTP server for testing of API.py-based modules
+    - nexus.py — command-line interface for Maven-compatible resources: upload, download, delete artifacts
+
+- templates (for possible future use):
+    - okd — template for Openshift OKD
 
 Dockerfile builds bdist\_wheels for all libraries. Resulting image can be used to deploy to pypi or as a source to directly import libraries.

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 from sys import version_info
 
-__version= "3.9.1"
+__version = "3.9.1"
 install_requires = ["requests"]
 tests_require = []
 

--- a/setup.py
+++ b/setup.py
@@ -1,52 +1,23 @@
-from setuptools import setup, find_packages
-import unittest
-from doctest import DocFileSuite
-import os
-from sys import version_info
-from datetime import datetime
+#!/usr/bin/env python3
 
-def dynamic_version(str_version):
-    """
-    Returns full version of a package
-    :param str_version: string, package version to append
-    :return: str_version with appended build_id
-    """
+from setuptools import setup
 
-    str_vfile = 'version.txt'
+__version= "3.8.3"
 
-    if not os.path.exists(str_vfile):
-        fl_out = open(str_vfile, 'w')
-        fl_out.write(datetime.strftime(datetime.now(), "%Y%m%d%H%M%S"))
-        fl_out.close()
-
-    fl_in = open(str_vfile)
-    str_bid = fl_in.read().strip()
-    fl_in.close()
-
-    return '.'.join([str_version, str_bid])
-
-
-MAJOR = 3
-MINOR = 9 
-RELEASE = 0
-
-install_requires = ["requests", "mock"]
+install_requires = ["requests"]
 tests_require = []
 
-if version_info.major == 2:
-    install_requires.append("enum")
-    tests_require.append("mock==2.0.0")
-
 spec = {
-    "name": "oc_cdtapi",
-    "version": dynamic_version('.'.join(list(map(lambda x: str(x), [MAJOR, MINOR, RELEASE])))),
+    "name": "oc-cdtapi",
+    "version": __version,
     "license": "Apache2.0",
     "description": "Custom Development python API libraries",
     "long_description": "",
     "long_description_content_type": "text/plain",
-    "packages": find_packages(),
+    "packages": ["oc_cdtapi"],
     "install_requires": install_requires,
     "tests_require": tests_require,
+    "python_requires": ">=3.6",
     "scripts": [
         "nexus.py"
     ],

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,19 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 from setuptools import setup
+from sys import version_info
 
-__version= "3.8.3"
-
+__version= "3.9.1"
 install_requires = ["requests"]
 tests_require = []
+
+if version_info.major >= 3:
+    python_requires = ">=3.6"
+else:
+    python_requires = ">=2.7,<3"
+    # these modlues comes with 3.6 and later intepreters but not included in 2.7
+    install_requires.append("mock==2.0.0") # needed for tests only but can not be installed with 'pip' if not specified here
+    install_requires.append("enum")
 
 spec = {
     "name": "oc-cdtapi",
@@ -17,11 +25,11 @@ spec = {
     "packages": ["oc_cdtapi"],
     "install_requires": install_requires,
     "tests_require": tests_require,
-    "python_requires": ">=3.6",
+    "python_requires": python_requires,
     "scripts": [
         "nexus.py"
     ],
-
 }
+
 
 setup(**spec)


### PR DESCRIPTION
#  Renamed to fit regulations: Package=oc-cdtapi, Module=oc_cdtapi
# Rid of "dynamic version"
# "Readme" updated